### PR TITLE
fix(dev): 修复 Windows 开发脚本启动失败问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## 下载最新版本
 
 **获取最新构建版本请前往 [Actions](../../actions) 页面下载：**
+
 - 🌐 **Web版本** - 下载 `web-build` 构建产物，解压后可直接部署
 - 💻 **Windows应用** - 下载 `windows-app` 构建产物，获取可执行安装包
 
@@ -18,7 +19,6 @@
 
 ![alt text](image.png)
 
-
 ## 主要功能
 
 - 角色卡管理器：无须打开 sillytavern，app 全功能解析编辑
@@ -29,24 +29,30 @@
 - 正则修正：提供智能文本选择器，无须了解正则，立刻生成
 - 工具箱：提供小工具
 
-
 ## 开发指南
 
 ### 1. 安装依赖
+
 ```bash
 pnpm install
 ```
 
 ### 2. 启动开发模式
+
+**Electron 桌面应用模式**：
+
 ```bash
 pnpm dev
 ```
-如需仅启动前端（不打开 Electron）：
+
+**Web-only 模式**：
+
 ```bash
-pnpm dev --on
+pnpm dev:web
 ```
 
 ### 3. 打包应用程序
+
 ```bash
 pnpm build:electron
 ```

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/electron/main.js",
   "scripts": {
     "dev": "node scripts/run-dev.mjs",
+    "dev:web": "node scripts/run-dev.mjs --web",
     "build": "vite build",
     "preview": "vite preview",
     "electron": "electron .",

--- a/scripts/run-dev.mjs
+++ b/scripts/run-dev.mjs
@@ -1,25 +1,35 @@
 import { spawn } from 'child_process';
 
 const rawArgs = process.argv.slice(2);
-const disableElectron = rawArgs.includes('--on') || rawArgs.includes('--on_electron');
-const viteArgs = rawArgs.filter((arg) => arg !== '--on' && arg !== '--on_electron');
+const webOnly = rawArgs.includes('--web') || rawArgs.includes('--on');
+const viteArgs = rawArgs.filter((arg) => !['--web', '--on', '--on_electron'].includes(arg));
 
+// Windows requires shell: true to resolve .cmd scripts in node_modules/.bin
+const isWindows = process.platform === 'win32';
+
+/**
+ * Spawn a child process and forward exit code.
+ * Uses shell mode on Windows to correctly resolve npm/pnpm binaries.
+ */
 const spawnWithExit = (cmd, args, extraEnv = {}) => {
   const child = spawn(cmd, args, {
     stdio: 'inherit',
-    // Avoid shell concatenation so concurrently receives proper argv.
-    shell: false,
+    shell: isWindows,
     env: { ...process.env, ...extraEnv },
+  });
+  child.on('error', (err) => {
+    console.error(`Failed to execute command: ${cmd}`, err);
+    process.exit(1);
   });
   child.on('exit', (code) => process.exit(code ?? 0));
 };
 
-if (disableElectron) {
+if (webOnly) {
+  // Web-only mode: disable Electron plugin, run pure Vite dev server
+  console.log('Starting in Web-only mode...');
   spawnWithExit('vite', viteArgs, { DISABLE_ELECTRON: '1' });
 } else {
-  const viteCmd = ['vite', ...viteArgs].join(' ');
-  const electronCmd = 'wait-on http://localhost:3066 && electron .';
-  spawnWithExit('concurrently', ['--kill-others', '--success', 'first', viteCmd, electronCmd], {
-    ELECTRON_EXTERNAL: '1',
-  });
+  // Electron mode: vite-plugin-electron handles Electron startup automatically
+  console.log('Starting in Electron mode...');
+  spawnWithExit('vite', viteArgs, {});
 }


### PR DESCRIPTION
## 问题描述
在 Windows 环境下执行 pnpm dev 时，由于 shell: false 无法解析 node_modules/.bin 下的 .cmd 脚本，导致 spawn concurrently ENOENT 错误。

## 修复方案
重构开发脚本 - 移除冗余的 concurrently + wait-on，直接使用 vite-plugin-electron 内置的 Electron 自动启动功能
添加 Windows 兼容 - 在 Windows 平台使用 shell: true 确保正确解析 npm 脚本
新增 Web-only 模式 - 添加 pnpm dev:web 命令